### PR TITLE
feat : 회원 저장 로직 구현

### DIFF
--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/command/SignUpCommand.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/command/SignUpCommand.kt
@@ -1,7 +1,16 @@
 package com.coinkiri.application.port.`in`.command
 
+import com.coinkiri.domain.member.MemberCreate
+import com.coinkiri.domain.member.SocialType
+
 data class SignUpCommand(
     val token: String,
-    val socialType: String,
+    val socialType: SocialType,
     val nickname: String
-)
+) {
+    fun to(socialId: String) = MemberCreate(
+        socialId = socialId,
+        socialType = socialType,
+        nickname = nickname
+    )
+}

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/command/SignUpCommand.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/command/SignUpCommand.kt
@@ -1,0 +1,7 @@
+package com.coinkiri.application.port.`in`.command
+
+data class SignUpCommand(
+    val token: String,
+    val socialType: String,
+    val nickname: String
+)

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/usecase/AuthUseCase.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/usecase/AuthUseCase.kt
@@ -1,6 +1,8 @@
 package com.coinkiri.application.port.`in`.usecase
 
+import com.coinkiri.application.port.`in`.command.SignUpCommand
+
 interface AuthUseCase {
 
-    fun signUp(accessToken: String)
+    fun signUp(signUpCommand: SignUpCommand)
 }

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/usecase/AuthUseCase.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/usecase/AuthUseCase.kt
@@ -2,5 +2,5 @@ package com.coinkiri.application.port.`in`.usecase
 
 interface AuthUseCase {
 
-    fun signUp()
+    fun signUp(accessToken: String)
 }

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/usecase/AuthUseCase.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/usecase/AuthUseCase.kt
@@ -1,8 +1,9 @@
 package com.coinkiri.application.port.`in`.usecase
 
 import com.coinkiri.application.port.`in`.command.SignUpCommand
+import com.coinkiri.domain.member.Member
 
 interface AuthUseCase {
 
-    fun signUp(signUpCommand: SignUpCommand)
+    fun signUp(signUpCommand: SignUpCommand): Member
 }

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/out/oauth2/KakaoApiCaller.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/out/oauth2/KakaoApiCaller.kt
@@ -2,7 +2,7 @@ package com.coinkiri.application.port.out.oauth2
 
 import com.coinkiri.application.service.auth.dto.KakaoProfileResponse
 
-interface OAuthApiCaller {
+interface KakaoApiCaller {
 
     fun getProfile(accessToken: String): KakaoProfileResponse
 }

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/out/oauth2/OAuthApiCaller.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/out/oauth2/OAuthApiCaller.kt
@@ -1,6 +1,6 @@
 package com.coinkiri.application.port.out.oauth2
 
-import com.coinkiri.application.KakaoProfileResponse
+import com.coinkiri.application.service.auth.dto.KakaoProfileResponse
 
 interface OAuthApiCaller {
 

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/AuthServiceProvider.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/AuthServiceProvider.kt
@@ -1,0 +1,25 @@
+package com.coinkiri.application.service.auth
+
+import com.coinkiri.application.port.`in`.usecase.AuthUseCase
+import com.coinkiri.domain.member.SocialType
+import jakarta.annotation.PostConstruct
+import org.springframework.stereotype.Component
+
+@Component
+class AuthServiceProvider(
+    private val kakaoAuthService: KakaoAuthService
+) {
+    companion object {
+        val authServiceMap = mutableMapOf<SocialType, AuthUseCase>()
+    }
+
+    @PostConstruct
+    fun initAuthServiceMap() {
+        authServiceMap[SocialType.KAKAO] = kakaoAuthService
+        // TODO authServiceMap[SocialType.NAVER] = naverAuthService
+    }
+
+    fun getAuthService(socialType: SocialType): AuthUseCase {
+        return authServiceMap[socialType]!!
+    }
+}

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/KakaoAuthService.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/KakaoAuthService.kt
@@ -1,17 +1,18 @@
 package com.coinkiri.application.service.auth
 
 import com.coinkiri.application.port.`in`.usecase.AuthUseCase
-import com.coinkiri.application.port.out.oauth2.OAuthApiCaller
+import com.coinkiri.application.port.out.oauth2.KakaoApiCaller
 import com.coinkiri.application.service.member.MemberService
 import org.springframework.stereotype.Service
 
 @Service
 class KakaoAuthService(
-    private val oAuthApiCaller: OAuthApiCaller,
+    private val kakaoApiCaller: KakaoApiCaller,
     private val memberService: MemberService
 ) : AuthUseCase {
 
-    override fun signUp() {
-        TODO("Not yet implemented")
+    override fun signUp(accessToken: String) {
+        val kakaoProfile = kakaoApiCaller.getProfile(accessToken)
+        // TODO member save
     }
 }

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/KakaoAuthService.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/KakaoAuthService.kt
@@ -1,7 +1,8 @@
-package com.coinkiri.application
+package com.coinkiri.application.service.auth
 
 import com.coinkiri.application.port.`in`.usecase.AuthUseCase
 import com.coinkiri.application.port.out.oauth2.OAuthApiCaller
+import com.coinkiri.application.service.member.MemberService
 import org.springframework.stereotype.Service
 
 @Service

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/KakaoAuthService.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/KakaoAuthService.kt
@@ -4,6 +4,7 @@ import com.coinkiri.application.port.`in`.command.SignUpCommand
 import com.coinkiri.application.port.`in`.usecase.AuthUseCase
 import com.coinkiri.application.port.out.oauth2.KakaoApiCaller
 import com.coinkiri.application.service.member.MemberService
+import com.coinkiri.domain.member.Member
 import org.springframework.stereotype.Service
 
 @Service
@@ -12,8 +13,9 @@ class KakaoAuthService(
     private val memberService: MemberService
 ) : AuthUseCase {
 
-    override fun signUp(signUpCommand: SignUpCommand) {
+    override fun signUp(signUpCommand: SignUpCommand): Member {
         val kakaoProfile = kakaoApiCaller.getProfile(signUpCommand.token)
-        // TODO member save
+        val member = memberService.create(signUpCommand.to(kakaoProfile.socialId))
+        return member
     }
 }

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/KakaoAuthService.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/KakaoAuthService.kt
@@ -1,5 +1,6 @@
 package com.coinkiri.application.service.auth
 
+import com.coinkiri.application.port.`in`.command.SignUpCommand
 import com.coinkiri.application.port.`in`.usecase.AuthUseCase
 import com.coinkiri.application.port.out.oauth2.KakaoApiCaller
 import com.coinkiri.application.service.member.MemberService
@@ -11,8 +12,8 @@ class KakaoAuthService(
     private val memberService: MemberService
 ) : AuthUseCase {
 
-    override fun signUp(accessToken: String) {
-        val kakaoProfile = kakaoApiCaller.getProfile(accessToken)
+    override fun signUp(signUpCommand: SignUpCommand) {
+        val kakaoProfile = kakaoApiCaller.getProfile(signUpCommand.token)
         // TODO member save
     }
 }

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/dto/KakaoProfileResponse.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/dto/KakaoProfileResponse.kt
@@ -1,4 +1,4 @@
-package com.coinkiri.application
+package com.coinkiri.application.service.auth.dto
 
 data class KakaoProfileResponse(
     val id: String

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/dto/KakaoProfileResponse.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/auth/dto/KakaoProfileResponse.kt
@@ -1,5 +1,5 @@
 package com.coinkiri.application.service.auth.dto
 
 data class KakaoProfileResponse(
-    val id: String
+    val socialId: String
 )

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/member/MemberService.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/member/MemberService.kt
@@ -1,4 +1,4 @@
-package com.coinkiri.application
+package com.coinkiri.application.service.member
 
 import com.coinkiri.application.port.`in`.usecase.MemberUseCase
 import com.coinkiri.application.port.out.jpa.MemberRepository

--- a/coinkiri-bootstrap/api/src/main/kotlin/com/coinkiri/api/adapter/controller/AuthController.kt
+++ b/coinkiri-bootstrap/api/src/main/kotlin/com/coinkiri/api/adapter/controller/AuthController.kt
@@ -1,7 +1,8 @@
 package com.coinkiri.api.adapter.controller
 
 import com.coinkiri.api.adapter.request.SignUpRequest
-import com.coinkiri.application.port.`in`.usecase.AuthUseCase
+import com.coinkiri.application.service.auth.AuthServiceProvider
+import com.coinkiri.domain.member.SocialType
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.PostMapping
@@ -13,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("api/v1/auth")
 class AuthController(
-    private val authUseCase: AuthUseCase
+    private val authServiceProvider: AuthServiceProvider
 ) {
 
     @Operation(summary = "소셜 로그인")
@@ -21,6 +22,8 @@ class AuthController(
     fun signUp(
         @RequestBody request: SignUpRequest
     ) {
-
+        val socialType = SocialType.valueOf(request.socialType)
+        val authService = authServiceProvider.getAuthService(socialType)
+        val member = authService.signUp(request.to())
     }
 }

--- a/coinkiri-bootstrap/api/src/main/kotlin/com/coinkiri/api/adapter/request/SignUpRequest.kt
+++ b/coinkiri-bootstrap/api/src/main/kotlin/com/coinkiri/api/adapter/request/SignUpRequest.kt
@@ -1,16 +1,15 @@
 package com.coinkiri.api.adapter.request
 
-import com.coinkiri.domain.member.MemberCreate
-import com.coinkiri.domain.member.SocialType
+import com.coinkiri.application.port.`in`.command.SignUpCommand
 
 data class SignUpRequest(
     val token: String,
     val socialType: String,
     val nickname: String
 ) {
-    fun to(socialId: String) = MemberCreate(
-        socialId = socialId,
-        socialType = SocialType.valueOf(socialType),
+    fun to() = SignUpCommand(
+        token = token,
+        socialType = socialType,
         nickname = nickname
     )
 }

--- a/coinkiri-bootstrap/api/src/main/kotlin/com/coinkiri/api/adapter/request/SignUpRequest.kt
+++ b/coinkiri-bootstrap/api/src/main/kotlin/com/coinkiri/api/adapter/request/SignUpRequest.kt
@@ -1,6 +1,7 @@
 package com.coinkiri.api.adapter.request
 
 import com.coinkiri.application.port.`in`.command.SignUpCommand
+import com.coinkiri.domain.member.SocialType
 
 data class SignUpRequest(
     val token: String,
@@ -9,7 +10,7 @@ data class SignUpRequest(
 ) {
     fun to() = SignUpCommand(
         token = token,
-        socialType = socialType,
+        socialType = SocialType.valueOf(socialType),
         nickname = nickname
     )
 }

--- a/coinkiri-infrastructure/oauth2/src/main/kotlin/com/coinkiri/oauth2/adapter/kakao/KakaoApiCallerAdapter.kt
+++ b/coinkiri-infrastructure/oauth2/src/main/kotlin/com/coinkiri/oauth2/adapter/kakao/KakaoApiCallerAdapter.kt
@@ -1,6 +1,6 @@
 package com.coinkiri.oauth2.adapter.kakao
 
-import com.coinkiri.application.port.out.oauth2.OAuthApiCaller
+import com.coinkiri.application.port.out.oauth2.KakaoApiCaller
 import com.coinkiri.application.service.auth.dto.KakaoProfileResponse
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -8,7 +8,7 @@ import org.springframework.web.reactive.function.client.WebClient
 @Component
 class KakaoApiCallerAdapter(
     private val webClient: WebClient
-) : OAuthApiCaller {
+) : KakaoApiCaller {
 
     override fun getProfile(accessToken: String): KakaoProfileResponse {
         return webClient.get()

--- a/coinkiri-infrastructure/oauth2/src/main/kotlin/com/coinkiri/oauth2/adapter/kakao/KakaoApiCallerAdapter.kt
+++ b/coinkiri-infrastructure/oauth2/src/main/kotlin/com/coinkiri/oauth2/adapter/kakao/KakaoApiCallerAdapter.kt
@@ -9,7 +9,7 @@ import org.springframework.web.reactive.function.client.WebClient
 class KakaoApiCallerAdapter(
     private val webClient: WebClient
 ) : KakaoApiCaller {
-
+    
     override fun getProfile(accessToken: String): KakaoProfileResponse {
         return webClient.get()
             .uri("https://kapi.kakao.com/v2/user/me")

--- a/coinkiri-infrastructure/oauth2/src/main/kotlin/com/coinkiri/oauth2/adapter/kakao/KakaoApiCallerAdapter.kt
+++ b/coinkiri-infrastructure/oauth2/src/main/kotlin/com/coinkiri/oauth2/adapter/kakao/KakaoApiCallerAdapter.kt
@@ -1,7 +1,7 @@
 package com.coinkiri.oauth2.adapter.kakao
 
-import com.coinkiri.application.KakaoProfileResponse
 import com.coinkiri.application.port.out.oauth2.OAuthApiCaller
+import com.coinkiri.application.service.auth.dto.KakaoProfileResponse
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- #9 

## 🔑 Key Changes

1. signUp 메서드 토큰 생성 전까지 구현
- 카카오 소셜 id 반환받기
- 멤버 도메인 저장하기

