### PR TITLE
feat : 오늘의 상승한 코인, 하락한 코인 개수 api 구현

### DIFF
--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/usecase/CountRiseFall.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/in/usecase/CountRiseFall.kt
@@ -1,0 +1,8 @@
+package com.coinkiri.application.port.`in`.usecase
+
+import com.coinkiri.domain.coin.RiseFallCount
+
+interface CountRiseFall {
+
+    fun countRiseAndFall(): RiseFallCount
+}

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/out/dto/TickerDto.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/out/dto/TickerDto.kt
@@ -1,0 +1,30 @@
+package com.coinkiri.application.port.out.dto
+
+data class TickerDto(
+    val market: String,
+    val trade_date: String,
+    val trade_time: String,
+    val trade_date_kst: String,
+    val trade_time_kst: String,
+    val trade_timestamp: Long,
+    val opening_price: Double,
+    val high_price: Double,
+    val low_price: Double,
+    val trade_price: Double,
+    val prev_closing_price: Double,
+    val change: String,
+    val change_price: Double,
+    val change_rate: Double,
+    val signed_change_price: Double,
+    val signed_change_rate: Double,
+    val trade_volume: Double,
+    val acc_trade_price: Double,
+    val acc_trade_price_24h: Double,
+    val acc_trade_volume: Double,
+    val acc_trade_volume_24h: Double,
+    val highest_52_week_price: Double,
+    val highest_52_week_date: String,
+    val lowest_52_week_price: Double,
+    val lowest_52_week_date: String,
+    val timestamp: Long
+)

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/out/upbit/UpbitApiCaller.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/out/upbit/UpbitApiCaller.kt
@@ -2,6 +2,7 @@ package com.coinkiri.application.port.out.upbit
 
 import com.coinkiri.domain.coin.CoinCreate
 import com.coinkiri.domain.coin.CoinDetail
+import com.coinkiri.domain.coin.RiseFallCount
 
 interface UpbitApiCaller {
 
@@ -9,5 +10,5 @@ interface UpbitApiCaller {
 
     fun getCoinDetail(market: String): CoinDetail
 
-    fun isRiseOrFall(market: String): Boolean
+    fun getRiseAndFallCount(marketList: List<String>): RiseFallCount
 }

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/out/upbit/UpbitApiCaller.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/port/out/upbit/UpbitApiCaller.kt
@@ -8,4 +8,6 @@ interface UpbitApiCaller {
     fun getCoinList(): List<CoinCreate>
 
     fun getCoinDetail(market: String): CoinDetail
+
+    fun isRiseOrFall(market: String): Boolean
 }

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/coin/CountRiseFallService.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/coin/CountRiseFallService.kt
@@ -16,18 +16,6 @@ class CountRiseFallService(
 
         val marketList = coinRepository.findAll().map { it.marketName }
 
-        var riseCount = 0
-        var fallCount = 0
-
-        marketList.forEach {
-            if (upbitApiCaller.isRiseOrFall(it)) {
-                riseCount++
-            } else {
-                fallCount++
-            }
-            Thread.sleep(100)
-        }
-
-        return RiseFallCount(riseCount, fallCount)
+        return upbitApiCaller.getRiseAndFallCount(marketList)
     }
 }

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/coin/CountRiseFallService.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/coin/CountRiseFallService.kt
@@ -1,16 +1,33 @@
 package com.coinkiri.application.service.coin
 
 import com.coinkiri.application.port.`in`.usecase.CountRiseFall
+import com.coinkiri.application.port.out.jpa.CoinRepository
 import com.coinkiri.application.port.out.upbit.UpbitApiCaller
 import com.coinkiri.domain.coin.RiseFallCount
 import org.springframework.stereotype.Service
 
 @Service
 class CountRiseFallService(
-    private val upbitApiCaller: UpbitApiCaller
+    private val upbitApiCaller: UpbitApiCaller,
+    private val coinRepository: CoinRepository
 ) : CountRiseFall {
 
     override fun countRiseAndFall(): RiseFallCount {
-        TODO("Not yet implemented")
+
+        val marketList = coinRepository.findAll().map { it.marketName }
+
+        var riseCount = 0
+        var fallCount = 0
+
+        marketList.forEach {
+            if (upbitApiCaller.isRiseOrFall(it)) {
+                riseCount++
+            } else {
+                fallCount++
+            }
+            Thread.sleep(100)
+        }
+
+        return RiseFallCount(riseCount, fallCount)
     }
 }

--- a/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/coin/CountRiseFallService.kt
+++ b/coinkiri-application/src/main/kotlin/com/coinkiri/application/service/coin/CountRiseFallService.kt
@@ -1,0 +1,16 @@
+package com.coinkiri.application.service.coin
+
+import com.coinkiri.application.port.`in`.usecase.CountRiseFall
+import com.coinkiri.application.port.out.upbit.UpbitApiCaller
+import com.coinkiri.domain.coin.RiseFallCount
+import org.springframework.stereotype.Service
+
+@Service
+class CountRiseFallService(
+    private val upbitApiCaller: UpbitApiCaller
+) : CountRiseFall {
+
+    override fun countRiseAndFall(): RiseFallCount {
+        TODO("Not yet implemented")
+    }
+}

--- a/coinkiri-bootstrap/api/src/main/kotlin/com/coinkiri/api/adapter/controller/CoinController.kt
+++ b/coinkiri-bootstrap/api/src/main/kotlin/com/coinkiri/api/adapter/controller/CoinController.kt
@@ -1,5 +1,7 @@
 package com.coinkiri.api.adapter.controller
 
+import com.coinkiri.api.adapter.response.RiseFallResponse
+import com.coinkiri.application.port.`in`.usecase.CountRiseFall
 import com.coinkiri.application.port.`in`.usecase.FindAllCoin
 import com.coinkiri.application.port.`in`.usecase.GetCoinDetail
 import com.coinkiri.common.response.ApiResponse
@@ -17,7 +19,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("api/v1/coin")
 class CoinController(
     private val findAllCoin: FindAllCoin,
-    private val getCoinDetail: GetCoinDetail
+    private val getCoinDetail: GetCoinDetail,
+    private val countRiseFall: CountRiseFall
 ) {
 
     @Operation(summary = "코인 리스트 조회")
@@ -38,5 +41,14 @@ class CoinController(
         val coinDetail = getCoinDetail.getCoinDetail(market)
 
         return ResponseEntity.ok(ApiResponse.success(coinDetail))
+    }
+
+    @Operation(summary = "오늘의 상승, 하락 코인 개수 조회")
+    @GetMapping("/count/rise-fall")
+    fun countRiseAndFall(): ResponseEntity<ApiResponse<RiseFallResponse>> {
+
+        val riseAndFallCount = countRiseFall.countRiseAndFall()
+
+        return ResponseEntity.ok(ApiResponse.success(RiseFallResponse.of(riseAndFallCount)))
     }
 }

--- a/coinkiri-bootstrap/api/src/main/kotlin/com/coinkiri/api/adapter/response/RiseFallResponse.kt
+++ b/coinkiri-bootstrap/api/src/main/kotlin/com/coinkiri/api/adapter/response/RiseFallResponse.kt
@@ -1,0 +1,17 @@
+package com.coinkiri.api.adapter.response
+
+import com.coinkiri.domain.coin.RiseFallCount
+
+data class RiseFallResponse(
+    val riseCount: Int,
+    val fallCount: Int
+) {
+    companion object {
+        fun of(riseFallCount: RiseFallCount): RiseFallResponse {
+            return RiseFallResponse(
+                riseCount = riseFallCount.riseCount,
+                fallCount = riseFallCount.fallCount
+            )
+        }
+    }
+}

--- a/coinkiri-domain/src/main/kotlin/com/coinkiri/domain/coin/RiseFallCount.kt
+++ b/coinkiri-domain/src/main/kotlin/com/coinkiri/domain/coin/RiseFallCount.kt
@@ -3,4 +3,19 @@ package com.coinkiri.domain.coin
 data class RiseFallCount(
     val riseCount: Int,
     val fallCount: Int
-)
+) {
+    companion object {
+        fun count(rateList: List<Double>): RiseFallCount {
+            var riseCount = 0
+            var fallCount = 0
+            rateList.forEach {
+                if (it >= 0) {
+                    riseCount++
+                } else {
+                    fallCount++
+                }
+            }
+            return RiseFallCount(riseCount, fallCount)
+        }
+    }
+}

--- a/coinkiri-domain/src/main/kotlin/com/coinkiri/domain/coin/RiseFallCount.kt
+++ b/coinkiri-domain/src/main/kotlin/com/coinkiri/domain/coin/RiseFallCount.kt
@@ -1,0 +1,6 @@
+package com.coinkiri.domain.coin
+
+data class RiseFallCount(
+    val riseCount: Int,
+    val fallCount: Int
+)

--- a/coinkiri-infrastructure/upbit/src/main/kotlin/com/coinkiri/upbit/adapter/UpbitApiCallerAdapter.kt
+++ b/coinkiri-infrastructure/upbit/src/main/kotlin/com/coinkiri/upbit/adapter/UpbitApiCallerAdapter.kt
@@ -48,7 +48,23 @@ class UpbitApiCallerAdapter(
         } catch (e: Exception) {
             log.error(e) { "Error fetching coin detail" }
         }
-        
+
         return CoinDetail(market, emptyList())
+    }
+
+    override fun isRiseOrFall(market: String): Boolean {
+        val coinRequestUrl = "https://api.upbit.com/v1/candles/days?market=$market&count=1"
+
+        try {
+            val response = restTemplate.getForObject(coinRequestUrl, Array<CoinDetailDto>::class.java)
+                ?: throw RuntimeException("Upbit API 응답이 null입니다.")
+            
+            log.info { "Coin detail: ${response.first().change_rate}" }
+            return response.first().change_rate >= 0
+
+        } catch (e: Exception) {
+            log.error(e) { "Error fetching coin detail" }
+            return false
+        }
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- #23 

## 🔑 Key Changes

이 PR에서 변경된 내용을 간략하게 적어주세요.

1. 시세 캔들 조회 시 1초당 10번의 요청 제한
2. 코인은 총 130개로 13초의 응답 지연 시간 발생
3. 시세 캔들 조회 -> 시세 현재가 조회로 api 변경
4. 모든 코인을 한번의 요청으로 해결

